### PR TITLE
Bug custom expression feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 
   <packageRestore>
@@ -11,7 +11,11 @@
   </activePackageSource>
 
   <packageSources>
+
     <add key="Octopus-Dependencies" value="https://www.myget.org/F/octopus-dependencies/api/v3/index.json" />
+
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+
   </packageSources>
 
   <disabledPackageSources>

--- a/source/Octopus.Cli/Commands/ImportCommand.cs
+++ b/source/Octopus.Cli/Commands/ImportCommand.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using log4net;
+﻿using log4net;
 using Octopus.Cli.Importers;
 using Octopus.Cli.Infrastructure;
 using Octopus.Cli.Util;

--- a/source/Octopus.Cli/Exporters/ProjectExporter.cs
+++ b/source/Octopus.Cli/Exporters/ProjectExporter.cs
@@ -83,6 +83,7 @@ namespace Octopus.Cli.Exporters
                     PropertyValueResource nugetFeedId;
                     if (action.Properties.TryGetValue("Octopus.Action.Package.NuGetFeedId", out nugetFeedId))
                     {
+                        Log.Debug("Finding NuGet feed for step " + step.Name);
                         FeedResource feed = null;
                         if (FeedResourceCustomExpressionHelper.IsValidRepositoryId(nugetFeedId.Value))
                             feed = Repository.Feeds.Get(nugetFeedId.Value);

--- a/source/Octopus.Cli/Exporters/ProjectExporter.cs
+++ b/source/Octopus.Cli/Exporters/ProjectExporter.cs
@@ -84,10 +84,10 @@ namespace Octopus.Cli.Exporters
                     {
                         Log.Debug("Finding NuGet feed for step " + step.Name);
                         FeedResource feed = null;
-                        if (FeedResourceCustomExpressionHelper.IsValidRepositoryId(nugetFeedId.Value))
+                        if (FeedCustomExpressionHelper.IsRealFeedId(nugetFeedId.Value))
                             feed = Repository.Feeds.Get(nugetFeedId.Value);
                         else
-                            feed = FeedResourceCustomExpressionHelper.FeedResourceWithId(nugetFeedId.Value);
+                            feed = FeedCustomExpressionHelper.CustomExpressionFeedWithId(nugetFeedId.Value);
 
                         if (feed == null)
                             throw new CouldNotFindException("NuGet feed for step", step.Name);

--- a/source/Octopus.Cli/Exporters/ProjectExporter.cs
+++ b/source/Octopus.Cli/Exporters/ProjectExporter.cs
@@ -74,7 +74,6 @@ namespace Octopus.Cli.Exporters
                 throw new CouldNotFindException("deployment process for project",project.Name);
 
             Log.Debug("Finding NuGet feed for deployment process...");
-
             var nugetFeeds = new List<ReferenceDataItem>();
             foreach (var step in deploymentProcess.Steps)
             {

--- a/source/Octopus.Cli/Importers/ProjectImporter.cs
+++ b/source/Octopus.Cli/Importers/ProjectImporter.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Security.Permissions;
 using log4net;
 using Octopus.Cli.Commands;
 using Octopus.Cli.Extensions;
@@ -37,8 +36,7 @@ namespace Octopus.Cli.Importers
             public IDictionary<string, ActionTemplateResource> Templates { get; set; }
             public VariableSetResource VariableSet { get; set; }
             public IEnumerable<ChannelResource> Channels { get; set; } 
-            public IDictionary<string, LifecycleResource> ChannelLifecycles { get; set; } 
-
+            public IDictionary<string, LifecycleResource> ChannelLifecycles { get; set; }
         }
 
         public ProjectImporter(IOctopusRepository repository, IOctopusFileSystem fileSystem, ILog log)
@@ -59,6 +57,7 @@ namespace Octopus.Cli.Importers
                 {
                     throw new CommandException("Unable to find a lifecycle to assign to this project.");
                 }
+
                 Log.DebugFormat("Found lifecycle '{0}'", existingLifecycle.Name);
                 project.LifecycleId = existingLifecycle.Id;
             }
@@ -470,7 +469,6 @@ namespace Octopus.Cli.Importers
                 }
                 else
                 {
-
                     Log.Debug("Channel does not exist, a new channel will be created");
                     channel.ProjectId = importedProject.Id;
                     if (channel.LifecycleId != null)
@@ -516,7 +514,6 @@ namespace Octopus.Cli.Importers
 
             return Repository.Projects.Create(project);
         }
-
        
         protected CheckedReferences<ProjectGroupResource> CheckProjectGroup(ReferenceDataItem projectGroup)
         {
@@ -546,7 +543,12 @@ namespace Octopus.Cli.Importers
             var dependencies = new CheckedReferences<FeedResource>();
             foreach (var nugetFeed in nugetFeeds)
             {
-                var feed = Repository.Feeds.FindByName(nugetFeed.Name);
+                FeedResource feed = null;
+                if (FeedResourceCustomExpressionHelper.IsValidRepositoryId(nugetFeed.Id))
+                    feed = Repository.Feeds.FindByName(nugetFeed.Name);
+                else
+                    feed = FeedResourceCustomExpressionHelper.FeedResourceWithId(nugetFeed.Id);
+
                 dependencies.Register(nugetFeed.Name, nugetFeed.Id, feed);
             }
             return dependencies;

--- a/source/Octopus.Cli/Importers/ProjectImporter.cs
+++ b/source/Octopus.Cli/Importers/ProjectImporter.cs
@@ -544,10 +544,10 @@ namespace Octopus.Cli.Importers
             foreach (var nugetFeed in nugetFeeds)
             {
                 FeedResource feed = null;
-                if (FeedResourceCustomExpressionHelper.IsValidRepositoryId(nugetFeed.Id))
+                if (FeedCustomExpressionHelper.IsRealFeedId(nugetFeed.Id))
                     feed = Repository.Feeds.FindByName(nugetFeed.Name);
                 else
-                    feed = FeedResourceCustomExpressionHelper.FeedResourceWithId(nugetFeed.Id);
+                    feed = FeedCustomExpressionHelper.CustomExpressionFeedWithId(nugetFeed.Id);
 
                 dependencies.Register(nugetFeed.Name, nugetFeed.Id, feed);
             }

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -121,7 +121,7 @@
     <Compile Include="Repositories\ActionTemplateRepository.cs" />
     <Compile Include="Repositories\IActionTemplateRepository.cs" />
     <Compile Include="Util\DeletionOptions.cs" />
-    <Compile Include="Util\FeedResourceCustomExpressionHelper.cs" />
+    <Compile Include="Util\FeedCustomExpressionHelper.cs" />
     <Compile Include="Util\Humanize.cs" />
     <Compile Include="Util\IOctopusFileSystem.cs" />
     <Compile Include="Util\LineSplitter.cs" />

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Repositories\ActionTemplateRepository.cs" />
     <Compile Include="Repositories\IActionTemplateRepository.cs" />
     <Compile Include="Util\DeletionOptions.cs" />
+    <Compile Include="Util\FeedResourceCustomExpressionHelper.cs" />
     <Compile Include="Util\Humanize.cs" />
     <Compile Include="Util\IOctopusFileSystem.cs" />
     <Compile Include="Util\LineSplitter.cs" />

--- a/source/Octopus.Cli/Util/FeedCustomExpressionHelper.cs
+++ b/source/Octopus.Cli/Util/FeedCustomExpressionHelper.cs
@@ -1,20 +1,21 @@
 ﻿using Octopus.Client.Model;
+using System;
 
 namespace Octopus.Cli.Util
 {
     /// <summary>
     /// Helps with situations where feeds use custom expressions Eg. #{MyCustomFeedURL}
     /// </summary>
-    public static class FeedResourceCustomExpressionHelper
+    public static class FeedCustomExpressionHelper
     {
-        public static string FeedName = "Custom expression";
+        public static string CustomExpressionFeedName = "Custom expression";
 
-        public static FeedResource FeedResourceWithId(string id)
+        public static FeedResource CustomExpressionFeedWithId(string id)
         {
             var feed = new FeedResource()
             {
                 Id = id,
-                Name = FeedResourceCustomExpressionHelper.FeedName
+                Name = FeedCustomExpressionHelper.CustomExpressionFeedName
             };
             return feed;
         }
@@ -29,9 +30,9 @@ namespace Octopus.Cli.Util
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        public static bool IsValidRepositoryId(string id)
+        public static bool IsRealFeedId(string id)
         {
-            if (id.ToLowerInvariant().StartsWith("feeds-"))
+            if (id.StartsWith("feeds-", StringComparison.OrdinalIgnoreCase))
                 return true;
             return false;
         }

--- a/source/Octopus.Cli/Util/FeedResourceCustomExpressionHelper.cs
+++ b/source/Octopus.Cli/Util/FeedResourceCustomExpressionHelper.cs
@@ -3,7 +3,7 @@
 namespace Octopus.Cli.Util
 {
     /// <summary>
-    /// Helps with situation where feeds use custom expressions Eg. #{MyCustomFeedURL}
+    /// Helps with situations where feeds use custom expressions Eg. #{MyCustomFeedURL}
     /// </summary>
     public static class FeedResourceCustomExpressionHelper
     {

--- a/source/Octopus.Cli/Util/FeedResourceCustomExpressionHelper.cs
+++ b/source/Octopus.Cli/Util/FeedResourceCustomExpressionHelper.cs
@@ -1,0 +1,39 @@
+﻿using Octopus.Client.Model;
+
+namespace Octopus.Cli.Util
+{
+    /// <summary>
+    /// Helps with situation where feeds use custom expressions Eg. #{MyCustomFeedURL}
+    /// </summary>
+    public static class FeedResourceCustomExpressionHelper
+    {
+        public static string FeedName = "Custom expression";
+
+        public static FeedResource FeedResourceWithId(string id)
+        {
+            var feed = new FeedResource()
+            {
+                Id = id,
+                Name = FeedResourceCustomExpressionHelper.FeedName
+            };
+            return feed;
+        }
+
+        /// <summary>
+        /// Helps to check for a valid repository-based feed Id.
+        /// 
+        /// Feeds may have custom expressions as their Id, which may contain Octostache variable syntax #{MyCustomFeedURL}.
+        /// If you pass a custom expression Id like this to the API, it will resolve to /api/feeds/, return all the feeds, then
+        /// attempt to cast that response to a FeedResource object and you'll end up getting an empty FeedResource object instead 
+        /// of null. This method helps you detect valid repository feed objects before running into this confusing API scenario.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public static bool IsValidRepositoryId(string id)
+        {
+            if (id.ToLowerInvariant().StartsWith("feeds-"))
+                return true;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Fix to allow custom expressions in Nuget feeds for projects.

The exporter and importer were attempting to verify all feeds against the API, but there are times when the project has custom expressions for the feed ids using Octostache variables. So this fix makes sure we only check feeds against the API if they are _real_ DB records, and not a custom expression feed.

Fixes OctopusDeploy/Issues#2432