### PR TITLE
Add "create-channel" command.

### DIFF
--- a/source/Octopus.Cli.Tests/Commands/CreateChannelCommandFixture.cs
+++ b/source/Octopus.Cli.Tests/Commands/CreateChannelCommandFixture.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Linq;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Cli.Commands;
+using Octopus.Cli.Infrastructure;
+using Octopus.Client.Model;
+
+namespace Octopus.Cli.Tests.Commands
+{
+    public class CreateChannelCommandFixture : ApiCommandFixtureBase
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            createChannelCommand = new CreateChannelCommand(RepositoryFactory, Log, FileSystem);
+        }
+
+        CreateChannelCommand createChannelCommand;
+
+        [Test]
+        public void ShouldThrowBecauseOfMissingParameters()
+        {
+            Assert.Throws<CommandException>(() => createChannelCommand.Execute(CommandLineArgs.ToArray()));
+        }
+
+        [Test]
+        public void ShouldCreateNewChannel()
+        {
+            var projectName = $"Project-{Guid.NewGuid()}";
+            var project = new ProjectResource()
+            {
+                Links = new LinkCollection()
+            };
+            project.Links.Add("Channels", "DOES_NOT_MATTER");
+            Repository.Projects.FindByName(projectName).Returns(project);
+
+            var lifecycleName = $"Lifecycle-{Guid.NewGuid()}";
+            Repository.Lifecycles.FindOne(Arg.Any<Func<LifecycleResource, bool>>()).Returns(new LifecycleResource());
+
+            Repository.Client.List<ChannelResource>(Arg.Any<string>(), Arg.Any<object>())
+                .Returns(new ResourceCollection<ChannelResource>(Enumerable.Empty<ChannelResource>(), new LinkCollection()));
+
+            var channelName = $"Channel-{Guid.NewGuid()}";
+            CommandLineArgs.Add($"--channel={channelName}");
+            CommandLineArgs.Add($"--project={projectName}");
+            CommandLineArgs.Add($"--lifecycle={lifecycleName}");
+
+            createChannelCommand.Execute(CommandLineArgs.ToArray());
+
+            Log.Received().InfoFormat("Channel {0} created", channelName);
+        }
+
+        [Test]
+        public void ShouldUpdateExistingChannel()
+        {
+            var projectName = $"Project-{Guid.NewGuid()}";
+            var project = new ProjectResource()
+            {
+                Links = new LinkCollection()
+            };
+            project.Links.Add("Channels", "DOES_NOT_MATTER");
+            Repository.Projects.FindByName(projectName).Returns(project);
+
+            var lifecycleName = $"Lifecycle-{Guid.NewGuid()}";
+            Repository.Lifecycles.FindOne(Arg.Any<Func<LifecycleResource, bool>>()).Returns(new LifecycleResource());
+
+            var channelName = $"Channel-{Guid.NewGuid()}";
+            var channel = new ChannelResource()
+            {
+                Id = Guid.NewGuid().ToString(),
+                Name = channelName
+            };
+
+            Repository.Client.List<ChannelResource>(Arg.Any<string>(), Arg.Any<object>())
+                .Returns(new ResourceCollection<ChannelResource>(new[] { channel }, new LinkCollection()));
+
+            CommandLineArgs.Add($"--channel={channelName}");
+            CommandLineArgs.Add($"--project={projectName}");
+            CommandLineArgs.Add($"--lifecycle={lifecycleName}");
+            CommandLineArgs.Add("--update-if-exists");
+
+            createChannelCommand.Execute(CommandLineArgs.ToArray());
+
+            Log.Received().InfoFormat("Channel {0} updated", channelName);
+        }
+    }
+}

--- a/source/Octopus.Cli.Tests/Octopus.Cli.Tests.csproj
+++ b/source/Octopus.Cli.Tests/Octopus.Cli.Tests.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Commands\ApiCommandFixture.cs" />
     <Compile Include="Commands\ApiCommandFixtureBase.cs" />
     <Compile Include="Commands\CleanEnvironmentCommandFixture.cs" />
+    <Compile Include="Commands\CreateChannelCommandFixture.cs" />
     <Compile Include="Commands\DeployReleaseCommandTestFixture.cs" />
     <Compile Include="Commands\DummyApiCommand.cs" />
     <Compile Include="Commands\ListMachinesCommandFixture.cs" />

--- a/source/Octopus.Cli/Commands/CreateChannelCommand.cs
+++ b/source/Octopus.Cli/Commands/CreateChannelCommand.cs
@@ -48,13 +48,13 @@ namespace Octopus.Cli.Commands
             else
             {
                 Log.DebugFormat("Loading lifecycle {0}", lifecycleName);
-                var lifecycle = Repository.Lifecycles.FindOne(l => l.Name == lifecycleName);
+                var lifecycle = Repository.Lifecycles.FindOne(l => string.Compare(l.Name, lifecycleName, StringComparison.OrdinalIgnoreCase) == 0);
                 if (lifecycle == null) throw new CouldNotFindException("lifecycle named", lifecycleName);
                 lifecycleId = lifecycle.Id;
             }
 
             var channelsForThisProject = Repository.Client.List<ChannelResource>(project.Links["Channels"]);
-            var channel = channelsForThisProject.Items.FirstOrDefault(ch => ch.Name == channelName);
+            var channel = channelsForThisProject.Items.FirstOrDefault(ch => string.Compare(ch.Name, channelName, StringComparison.OrdinalIgnoreCase) == 0);
 
             if (channel == null)
             {

--- a/source/Octopus.Cli/Commands/CreateChannelCommand.cs
+++ b/source/Octopus.Cli/Commands/CreateChannelCommand.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using log4net;
+using Octopus.Cli.Infrastructure;
+using Octopus.Cli.Util;
+using Octopus.Client.Model;
+
+namespace Octopus.Cli.Commands
+{
+    [Command("create-channel", Description = "Creates a channel for a project")]
+    public class CreateChannelCommand : ApiCommand
+    {
+        public CreateChannelCommand(IOctopusRepositoryFactory repositoryFactory, ILog log, IOctopusFileSystem fileSystem) : base(repositoryFactory, log, fileSystem)
+        {
+            var options = Options.For("Create");
+            options.Add("channel=", "The name of the channel to create", s => channelName = s);
+            options.Add("description=", "A description of the channel", d => channelDescription = d);
+            options.Add("project=", "The name of the project in which to create the channel", p => projectName = p);
+            options.Add("lifecycle=", "The name of the lifecycle with which to create the channel", l => lifecycleName = l);
+            options.Add("make-default-channel", "Set the new channel to be the default channel", _ => makeDefaultChannel = true);
+            options.Add("update-if-exists", "Updates the channel if it already exists", _ => updateIfExists = true);
+        }
+
+        string channelName;
+        string projectName;
+        string lifecycleName;
+        string channelDescription;
+        bool updateIfExists;
+        bool? makeDefaultChannel;
+
+        protected override void Execute()
+        {
+            if (string.IsNullOrWhiteSpace(projectName)) throw new CommandException("Please specify a project using the parameter: --project=ProjectXYZ");
+            if (string.IsNullOrWhiteSpace(channelName)) throw new CommandException("Please specify a channel name using the parameter: --channel=ChannelXYZ");
+            if (string.IsNullOrWhiteSpace(lifecycleName)) throw new CommandException("Please specify a lifecycle name using the parameter: --lifecycle=LifecycleXYZ");
+
+            Log.DebugFormat("Loading project {0}", projectName);
+            var project = Repository.Projects.FindByName(projectName);
+            if (project == null) throw new CouldNotFindException("project named", projectName);
+
+            Log.DebugFormat("Loading lifecycle {0}", lifecycleName);
+            var lifecycle = Repository.Lifecycles.FindOne(l => l.Name == lifecycleName);
+            if (lifecycle == null) throw new CouldNotFindException("lifecycle named", lifecycleName);
+
+            var channelsForThisProject = Repository.Client.List<ChannelResource>(project.Links["Channels"]);
+            var channel = channelsForThisProject.Items.FirstOrDefault(ch => ch.Name == channelName);
+
+            if (channel == null)
+            {
+                channel = new ChannelResource()
+                {
+                    ProjectId = project.Id,
+                    Name = channelName,
+                    IsDefault = makeDefaultChannel ?? false,
+                    Description = channelDescription ?? string.Empty,
+                    LifecycleId = lifecycle.Id,
+                    Rules = new List<ChannelVersionRuleResource>(),
+                };
+
+                Log.DebugFormat("Creating channel {0}", channelName);
+                Repository.Channels.Create(channel);
+                Log.InfoFormat("Channel {0} created", channelName);
+            }
+            else
+            {
+                if (!updateIfExists) throw new CommandException("This channel already exists. If you would like to update it, please use the parameter: --update-if-exists");
+
+                channel.LifecycleId = lifecycle.Id;
+                channel.IsDefault = makeDefaultChannel ?? channel.IsDefault;
+                channel.Description = channelDescription ?? channel.Description;
+
+                Log.DebugFormat("Updating channel {0}", channelName);
+                Repository.Channels.Modify(channel);
+                Log.InfoFormat("Channel {0} updated", channelName);
+            }
+        }
+    }
+}

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -104,6 +104,7 @@
       <Link>Properties\VersionInfo.cs</Link>
     </Compile>
     <Compile Include="Commands\CleanEnvironmentCommand.cs" />
+    <Compile Include="Commands\CreateChannelCommand.cs" />
     <Compile Include="Commands\CreateEnvironmentCommand.cs" />
     <Compile Include="Commands\IPackageBuilder.cs" />
     <Compile Include="Commands\NuGetPackageBuilder.cs" />


### PR DESCRIPTION
# Rationale
The rationale behind this feature is to allow branch builds from TeamCity or other build servers to have a per-branch channel created for them.

`octo.exe create-channel --server=XYZ --apiKey=API-XYZ --channel="My New Channel" --project="My Project" --lifecycle=Default --update-if-exists`

# Use case
Use case: a team using short-lived feature branches wants to create a different IIS binding for each branch. The current best solution appears to be to parse a release version number or a package name and extract a branch name into an output variable.

This solution would allow a much cleaner creation of a channel for any given branch. I discussed this with @michaelnoonan a while ago and offered to send a pull request if the Octopus team didn't get around to building it first. Here it is :)

# Implementation
This is a fairly straight-forward wrapper over the Octopus REST API.

There's one small feature that might be noteworthy: the `--update-if-exists` parameter, which allows "create or update" behaviour.